### PR TITLE
MT-2173 Add opt-in `modId` tracking for record updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and fill in your credentials.
+# .env is gitignored. Used by `make test-integration`.
+
+FM_TEST_HOST=https://your.fmserver.com
+FM_TEST_DB=YourDatabase
+FM_TEST_USER=
+FM_TEST_PASS=
+
+# Any layout you have read/write access to.
+FM_TEST_LAYOUT=YourLayout
+
+# A writable text field on the layout above.
+FM_TEST_FIELD=SomeTextField

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: test test-integration
+
+# Run unit tests. Integration tests skip without FM_TEST_* env vars.
+test:
+	go test ./...
+
+# Run integration tests against a live FileMaker server.
+# Loads credentials from .env in the repo root (gitignored).
+test-integration:
+	@test -f .env || { echo "missing .env (see README: Running integration tests)"; exit 1; }
+	set -a; . ./.env; set +a; go test -v ./...

--- a/README.md
+++ b/README.md
@@ -375,3 +375,33 @@ The current `modId` is also exposed on the record:
 ``` go
 record.ModID
 ```
+
+# Running tests
+
+## Unit tests
+
+Pure unit tests cover field-data conversion, the `Record.Map` helper, and find-command construction. They have no external dependencies.
+
+```
+make test
+```
+
+(or just `go test ./...`). Integration tests are also included in this run but skip themselves when credentials aren't set, so this is safe in CI.
+
+## Integration tests
+
+A few tests (`TestModID_*`) exercise the live Data API and need credentials.
+
+To run them locally, copy `.env.example` to `.env` (gitignored) and fill in your credentials:
+
+```
+cp .env.example .env
+```
+
+Then run:
+
+```
+make test-integration
+```
+
+This sources `.env` and invokes `go test -v ./...`. Credentials never enter shell history.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ record.Set("field name", "new data")
 err := record.Commit()
 ```
 
+By default, `Commit()` uses last-write-wins — concurrent edits by another client will be silently overwritten. To enable optimistic concurrency, see [UseModID](#usemodid).
+
 ### Revert uncommitted changes
 
 ``` go
@@ -347,4 +349,29 @@ This method can be used to get a time object representing the time the last requ
 
 ``` go
 fm.LastActivity()
+```
+
+#### UseModID
+
+FileMaker assigns each record a `modId` that increments on every edit. When `UseModID` is enabled, `Commit()` sends the record's `modId` along with the field data, and FileMaker rejects the update if the record was modified by anyone else since it was read — giving you optimistic concurrency instead of last-write-wins.
+
+***Defaults to `false` for backwards compatibility. This default may change in a future major version.***
+
+``` go
+fm, _ := filemaker.New(/* ... */)
+fm.UseModID = true
+
+records, _ := fm.Find("layout name", /* ... */)
+record := records[0]
+record.Set("field name", "new data")
+
+//Returns an error if another client edited this record
+//between the Find and the Commit
+err := record.Commit()
+```
+
+The current `modId` is also exposed on the record:
+
+``` go
+record.ModID
 ```

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ record.ModID
 
 Pure unit tests cover field-data conversion, the `Record.Map` helper, and find-command construction. They have no external dependencies.
 
-```
+```sh
 make test
 ```
 
@@ -394,13 +394,13 @@ A few tests (`TestModID_*`) exercise the live Data API and need credentials.
 
 To run them locally, copy `.env.example` to `.env` (gitignored) and fill in your credentials:
 
-```
+```sh
 cp .env.example .env
 ```
 
 Then run:
 
-```
+```sh
 make test-integration
 ```
 

--- a/record.go
+++ b/record.go
@@ -19,6 +19,7 @@ import (
 // Record interface for some magic with methods
 type Record struct {
 	ID            string
+	ModID         string
 	Layout        string
 	StagedChanges map[string]interface{}
 	FieldData     map[string]interface{}
@@ -27,11 +28,14 @@ type Record struct {
 
 // newRecord returns a new instance of an existing record
 func newRecord(layout string, data interface{}, session Session) Record {
+	m := data.(map[string]interface{})
+	modID, _ := m["modId"].(string)
 	return Record{
-		ID:            data.(map[string]interface{})["recordId"].(string),
+		ID:            m["recordId"].(string),
+		ModID:         modID,
 		Layout:        layout,
 		StagedChanges: make(map[string]interface{}),
-		FieldData:     data.(map[string]interface{})["fieldData"].(map[string]interface{}),
+		FieldData:     m["fieldData"].(map[string]interface{}),
 		Session:       &session,
 	}
 }
@@ -86,14 +90,15 @@ func (r *Record) Commit() error {
 		return r.Create()
 	}
 
-	var jsonData = struct {
-		FieldData map[string]interface{} `json:"fieldData"`
-	}{
-		r.StagedChanges,
+	body := map[string]interface{}{
+		"fieldData": r.StagedChanges,
+	}
+	if r.Session.UseModID && r.ModID != "" {
+		body["modId"] = r.ModID
 	}
 
 	//Create the request json body
-	var requestBody, err = json.Marshal(jsonData)
+	var requestBody, err = json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request body: %v", err.Error())
 	}
@@ -130,6 +135,10 @@ func (r *Record) Commit() error {
 			jsonRes.Messages[0].Message,
 			jsonRes.Messages[0].Code,
 		)
+	}
+
+	if jsonRes.Response.ModID != "" {
+		r.ModID = jsonRes.Response.ModID
 	}
 
 	for fieldName, value := range r.StagedChanges {
@@ -314,8 +323,12 @@ func (r *Record) Create() error {
 	}
 
 	//Parse the field data for the record
-	for fieldname, val := range jsonRes.Response.Data[0].(map[string]interface{})["fieldData"].(map[string]interface{}) {
+	rec := jsonRes.Response.Data[0].(map[string]interface{})
+	for fieldname, val := range rec["fieldData"].(map[string]interface{}) {
 		r.FieldData[fieldname] = val
+	}
+	if mid, ok := rec["modId"].(string); ok {
+		r.ModID = mid
 	}
 
 	return nil

--- a/record.go
+++ b/record.go
@@ -93,6 +93,8 @@ func (r *Record) Commit() error {
 	body := map[string]interface{}{
 		"fieldData": r.StagedChanges,
 	}
+	// ModID is always populated by Find/Create on supported FMS versions;
+	// the empty check is defensive in case a caller hand-constructs a Record.
 	if r.Session.UseModID && r.ModID != "" {
 		body["modId"] = r.ModID
 	}

--- a/record_integration_test.go
+++ b/record_integration_test.go
@@ -1,0 +1,129 @@
+package filemaker
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// integrationSession returns a live session for integration tests.
+// Skips the test if the required environment variables are not set:
+//
+//	FM_TEST_HOST, FM_TEST_DB, FM_TEST_USER, FM_TEST_PASS,
+//	FM_TEST_LAYOUT, FM_TEST_FIELD (a writable text field on the layout)
+func integrationSession(t *testing.T) (*Session, string, string) {
+	t.Helper()
+	host := os.Getenv("FM_TEST_HOST")
+	db := os.Getenv("FM_TEST_DB")
+	user := os.Getenv("FM_TEST_USER")
+	pass := os.Getenv("FM_TEST_PASS")
+	layout := os.Getenv("FM_TEST_LAYOUT")
+	field := os.Getenv("FM_TEST_FIELD")
+	if host == "" || db == "" || user == "" || layout == "" || field == "" {
+		t.Skip("integration test skipped: set FM_TEST_HOST, FM_TEST_DB, FM_TEST_USER, FM_TEST_PASS, FM_TEST_LAYOUT, FM_TEST_FIELD")
+	}
+	fm, err := New(host, db, user, pass)
+	if err != nil {
+		t.Fatalf("filemaker.New: %v", err)
+	}
+	t.Cleanup(func() { _ = fm.Destroy() })
+	return fm, layout, field
+}
+
+// TestModID_PopulatedOnCreate verifies that a freshly created record
+// receives a modId from the Data API.
+func TestModID_PopulatedOnCreate(t *testing.T) {
+	fm, layout, field := integrationSession(t)
+
+	record := fm.NewRecord(layout)
+	record.Set(field, "modid-create-"+time.Now().Format(time.RFC3339Nano))
+	if err := record.Commit(); err != nil {
+		t.Fatalf("Commit (create): %v", err)
+	}
+	t.Cleanup(func() { _ = record.Delete() })
+
+	if record.ModID == "" {
+		t.Errorf("expected ModID to be populated after create, got empty string")
+	}
+}
+
+// TestModID_RefreshedOnEdit verifies that ModID advances after a successful edit
+// so that a subsequent commit on the same record uses the new value.
+func TestModID_RefreshedOnEdit(t *testing.T) {
+	fm, layout, field := integrationSession(t)
+	fm.UseModID = true
+
+	record := fm.NewRecord(layout)
+	record.Set(field, "modid-edit-"+time.Now().Format(time.RFC3339Nano))
+	if err := record.Commit(); err != nil {
+		t.Fatalf("Commit (create): %v", err)
+	}
+	t.Cleanup(func() { _ = record.Delete() })
+
+	before := record.ModID
+	if before == "" {
+		t.Fatalf("expected ModID populated after create")
+	}
+
+	record.Set(field, "modid-edit-after-"+time.Now().Format(time.RFC3339Nano))
+	if err := record.Commit(); err != nil {
+		t.Fatalf("Commit (edit) with current modId should succeed: %v", err)
+	}
+
+	if record.ModID == before {
+		t.Errorf("expected ModID to change after edit, still %q", record.ModID)
+	}
+}
+
+// TestModID_RejectsStaleEdit verifies that the server rejects an edit
+// committed with a stale modId (i.e. the record was updated by someone else
+// between read and write).
+func TestModID_RejectsStaleEdit(t *testing.T) {
+	fm, layout, field := integrationSession(t)
+	fm.UseModID = true
+
+	marker := "modid-stale-" + time.Now().Format(time.RFC3339Nano)
+
+	// Create the record with a unique marker so we can find it.
+	seed := fm.NewRecord(layout)
+	seed.Set(field, marker)
+	if err := seed.Commit(); err != nil {
+		t.Fatalf("Commit (create): %v", err)
+	}
+	t.Cleanup(func() { _ = seed.Delete() })
+
+	// Fetch the same row into two independent Record values.
+	findByMarker := func() Record {
+		recs, err := fm.Find(layout, NewFindCommand(
+			NewFindRequest(NewFindCriterion(field, "=="+marker)),
+		))
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		if len(recs) != 1 {
+			t.Fatalf("expected 1 record matching marker, got %d", len(recs))
+		}
+		return recs[0]
+	}
+	copyA := findByMarker()
+	copyB := findByMarker()
+
+	if copyA.ModID == "" || copyB.ModID == "" {
+		t.Fatalf("expected ModID populated on both copies, got A=%q B=%q", copyA.ModID, copyB.ModID)
+	}
+	if copyA.ModID != copyB.ModID {
+		t.Fatalf("expected both copies to have the same starting ModID, got A=%q B=%q", copyA.ModID, copyB.ModID)
+	}
+
+	// Edit copy A successfully — bumps the server's modId.
+	copyA.Set(field, marker+"-A")
+	if err := copyA.Commit(); err != nil {
+		t.Fatalf("Commit (copyA, fresh modId) should succeed: %v", err)
+	}
+
+	// Edit copy B with its now-stale modId — server should reject.
+	copyB.Set(field, marker+"-B")
+	if err := copyB.Commit(); err == nil {
+		t.Errorf("expected stale-modId Commit on copyB to be rejected, got nil error")
+	}
+}

--- a/record_integration_test.go
+++ b/record_integration_test.go
@@ -16,10 +16,10 @@ func integrationSession(t *testing.T) (*Session, string, string) {
 	host := os.Getenv("FM_TEST_HOST")
 	db := os.Getenv("FM_TEST_DB")
 	user := os.Getenv("FM_TEST_USER")
-	pass := os.Getenv("FM_TEST_PASS")
+	pass, passSet := os.LookupEnv("FM_TEST_PASS")
 	layout := os.Getenv("FM_TEST_LAYOUT")
 	field := os.Getenv("FM_TEST_FIELD")
-	if host == "" || db == "" || user == "" || layout == "" || field == "" {
+	if host == "" || db == "" || user == "" || !passSet || layout == "" || field == "" {
 		t.Skip("integration test skipped: set FM_TEST_HOST, FM_TEST_DB, FM_TEST_USER, FM_TEST_PASS, FM_TEST_LAYOUT, FM_TEST_FIELD")
 	}
 	fm, err := New(host, db, user, pass)

--- a/record_test.go
+++ b/record_test.go
@@ -10,6 +10,7 @@ func newTestRecord() Record {
 		"layout",
 		map[string]interface{}{
 			"recordId": "recordId",
+			"modId":    "1",
 			"fieldData": map[string]interface{}{
 				"string":              "string",
 				"int":                 float64(100),
@@ -285,6 +286,30 @@ func TestRecordMap(t *testing.T) {
 		got := value.NestedNilStructPointer
 		if got != nil {
 			t.Errorf("got: %v, expected: %v", got, nil)
+		}
+	})
+}
+
+// TestNewRecordModID verifies that newRecord populates ModID from the API response.
+func TestNewRecordModID(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		r := newTestRecord()
+		if r.ModID != "1" {
+			t.Errorf("got: %q, expected: %q", r.ModID, "1")
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		r := newRecord(
+			"layout",
+			map[string]interface{}{
+				"recordId":  "recordId",
+				"fieldData": map[string]interface{}{},
+			},
+			Session{},
+		)
+		if r.ModID != "" {
+			t.Errorf("got: %q, expected empty string", r.ModID)
 		}
 	})
 }

--- a/session.go
+++ b/session.go
@@ -20,6 +20,7 @@ type Session struct {
 	Database     string
 	Username     string
 	Password     string
+	UseModID     bool
 	lastActivity time.Time
 }
 


### PR DESCRIPTION
## Summary

Adds support for FileMaker's `modId` (modification id) so callers can opt into optimistic concurrency on record updates. With it enabled, `Commit()` sends the record's `modId` and FileMaker rejects the update if the record was edited by anyone else in the meantime — instead of silently overwriting their change.

## Changes

- New `Record.ModID` field, populated from the API response in `newRecord()` and refreshed after `Create()` and `Commit()`.
- New `Session.UseModID bool` setting. When `true`, `Commit()` includes `modId` in the PATCH body. When `false`, behaviour is unchanged.
- `modId` is parsed and stored on every record regardless of the setting, so flipping `UseModID` mid-session works without re-fetching.

## Default: opt-in

`UseModID` defaults to `false` to keep v3.x backwards-compatible — flipping it to `true` is a real behaviour change (existing callers would suddenly start seeing rejection errors on edits that previously succeeded silently). The plan is to flip the default to `true` in v4.

## Tests

- Unit tests verify `modId` parsing, including the "field absent" case for older servers.
- Integration tests (`TestModID_*`, gated on `FM_TEST_*` env vars, skipped without creds) verify against a live Data API that:
  - a created record receives a `modId`,
  - `ModID` advances after a successful edit,
  - committing with a stale `modId` is rejected.

A `.env.example` template, `make test` / `make test-integration` targets, and a "Running tests" section in the README make local runs straightforward without putting credentials in shell history.

## Test plan

- [x] `make test` passes
- [x] `make test-integration` passes against a live FileMaker server (with `.env` filled in)
- [x] Manual sanity check: existing v3 callers that don't touch `UseModID` see no behaviour change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Session.UseModID` support for optimistic concurrency and surfaced record `ModID` for create/edit flows.
* **Documentation**
  * Updated `Commit()` guidance to describe default last-write-wins behavior and how to enable `UseModID` for conflict detection.
* **Tests**
  * Added integration coverage for `ModID` population, refreshing after edits, and rejecting stale updates.
* **Chores**
  * Added integration test infrastructure: an `.env.example` template and `make test` / `make test-integration` targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->