### PR TITLE
MT-2361 Added `WithTimeout` option to allow customizing the FileMaker Data API timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ fm, err := filemaker.New(
   "database",
   "username",
   "password",
-  filemaker.WithTimout(10 * time.Second), // OPTIONAL: specify the HTTP request timeout, default is 30 seconds
+  filemaker.WithTimeout(10 * time.Second), // OPTIONAL: specify the HTTP request timeout, default is 30 seconds
 )
 if err != nil {
   fmt.Printf("Failed to start session: %s", err.Error())
@@ -347,7 +347,7 @@ fmt.Printf("%+v\n", hero)
 
 Default timeout is 30 seconds.
 
-The HTTP client timeout can be overriden with the `WithTimout` option when creating a new session.
+The HTTP client timeout can be overridden with the `WithTimeout` option when creating a new session.
 The timeout is applied to every HTTP request to the FileMaker server.
 
 Setting the timeout to 0 will disable the timeout completely.
@@ -360,7 +360,7 @@ filemaker.New(
   "database",
   "username",
   "password",
-  filemaker.WithTimout(60 * time.Second),
+  filemaker.WithTimeout(60 * time.Second),
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ fm, err := filemaker.New(
   "database",
   "username",
   "password",
+  filemaker.WithTimout(10 * time.Second), // OPTIONAL: specify the HTTP request timeout, default is 30 seconds
 )
 if err != nil {
   fmt.Printf("Failed to start session: %s", err.Error())
@@ -341,7 +342,40 @@ fmt.Printf("%+v\n", hero)
 ```
 
 ## Session
-#### Last activity time object
+
+### HTTP client timeout
+
+Default timeout is 30 seconds.
+
+The HTTP client timeout can be overriden with the `WithTimout` option when creating a new session.
+The timeout is applied to every HTTP request to the FileMaker server.
+
+Setting the timeout to 0 will disable the timeout completely.
+
+Overriding the default timeout:
+
+``` go
+filemaker.New(
+  "https://my.host.com",
+  "database",
+  "username",
+  "password",
+  filemaker.WithTimout(60 * time.Second),
+)
+```
+
+Using default timeout:
+
+``` go
+filemaker.New(
+  "https://my.host.com",
+  "database",
+  "username",
+  "password",
+)
+```
+
+### Last activity time object
 
 This method can be used to get a time object representing the time the last request was made using the session. Defaults to when the session was created until another request has been made.
 

--- a/session.go
+++ b/session.go
@@ -231,6 +231,9 @@ func New(host, database, username, password string, opts ...Option) (*Session, e
 	cfg := &config{timeout: 30 * time.Second}
 	// Apply any optional parameters
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		opt(cfg)
 	}
 

--- a/session.go
+++ b/session.go
@@ -191,8 +191,23 @@ func (s *Session) LastActivity() time.Time {
 	return s.lastActivity
 }
 
+// Option is used to configure optional parameters for New
+type Option func(*config)
+
+// config is used to store optional parameters for New
+type config struct {
+	timeout time.Duration
+}
+
+// WithTimeout sets the timeout for the http client
+func WithTimeout(timeout time.Duration) Option {
+	return func(c *config) {
+		c.timeout = timeout
+	}
+}
+
 // New starts a database session
-func New(host, database, username, password string) (*Session, error) {
+func New(host, database, username, password string, opts ...Option) (*Session, error) {
 	if host == "" {
 		return nil, errors.New("No host specified")
 	} else if database == "" {
@@ -212,6 +227,18 @@ func New(host, database, username, password string) (*Session, error) {
 		host = fmt.Sprintf("https://%s", host)
 	}
 
+	// Default parameters for the http client
+	cfg := &config{timeout: 30 * time.Second}
+	// Apply any optional parameters
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Setup a new http client with a timeout
+	var httpClient = &http.Client{
+		Timeout: cfg.timeout,
+	}
+
 	//Build and send request to the host
 	req, err := http.NewRequest(
 		"POST",
@@ -223,7 +250,7 @@ func New(host, database, username, password string) (*Session, error) {
 		"Authorization",
 		"Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+password)),
 	)
-	res, err := http.DefaultClient.Do(req)
+	res, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send POST request: %v", err.Error())
 	}
@@ -250,12 +277,12 @@ func New(host, database, username, password string) (*Session, error) {
 		)
 	}
 
-	// Create a new http client that automatically stores cookies
+	// Add a jar to the existing http client that automatically stores cookies
 	jar, _ := cookiejar.New(nil)
-	httpClient := http.Client{Jar: jar}
+	httpClient.Jar = jar
 
 	return &Session{
-		HttpClient:   &httpClient,
+		HttpClient:   httpClient,
 		Token:        jsonRes.Response.Token,
 		Host:         host,
 		Database:     database,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable HTTP client timeout support for sessions, with a default timeout of 30 seconds.

* **Documentation**
  * Updated Quickstart example demonstrating timeout configuration.
  * Extended session documentation with HTTP client timeout details and configuration guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MjukBiltvatt/go-filemaker/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->